### PR TITLE
fix: charge replay ordering, refund confirmation, and close idempotency

### DIFF
--- a/src/server/Charge.ts
+++ b/src/server/Charge.ts
@@ -30,7 +30,24 @@ export function charge(parameters: charge.Parameters) {
   const connection =
     parameters.connection ?? new Connection(clusterUrls[network], 'confirmed')
 
-  const pendingReferences = new Map<string, Keypair>()
+  // Per-signature mutex to prevent concurrent duplicate verification
+  const signatureLocks = new Map<string, Promise<void>>()
+
+  async function withSignatureLock<T>(sig: string, fn: () => Promise<T>): Promise<T> {
+    const existing = signatureLocks.get(sig) ?? Promise.resolve()
+    let resolve: () => void
+    const next = new Promise<void>((r) => { resolve = r })
+    signatureLocks.set(sig, next)
+    try {
+      await existing
+      return await fn()
+    } finally {
+      resolve!()
+      if (signatureLocks.get(sig) === next) {
+        signatureLocks.delete(sig)
+      }
+    }
+  }
 
   return Method.toServer(Methods.charge, {
     defaults: {
@@ -52,8 +69,6 @@ export function charge(parameters: charge.Parameters) {
       const referenceKeypair = Keypair.generate()
       const referenceKey = referenceKeypair.publicKey.toBase58()
 
-      pendingReferences.set(referenceKey, referenceKeypair)
-
       const recipientAta = await getAssociatedTokenAddress(mint, recipient)
 
       return {
@@ -74,40 +89,46 @@ export function charge(parameters: charge.Parameters) {
 
       const referenceKey = methodDetails.reference
 
-      if (store) {
-        const consumedKey = `solana-charge:consumed:${signature}`
-        if (await store.get(consumedKey)) {
-          throw new Error('Transaction signature already consumed')
+      return withSignatureLock(signature, async () => {
+        // Replay check inside lock to prevent concurrent duplicates
+        if (store) {
+          const consumedKey = `solana-charge:consumed:${signature}`
+          if (await store.get(consumedKey)) {
+            throw new Error('Transaction signature already consumed')
+          }
         }
-        await store.put(consumedKey, true)
-      }
 
-      const reference = new PublicKey(referenceKey)
-      const expectedRecipient = new PublicKey(methodDetails.recipient)
-      const expectedMint = new PublicKey(methodDetails.mint)
+        const reference = new PublicKey(referenceKey)
+        const expectedRecipient = new PublicKey(methodDetails.recipient)
+        const expectedMint = new PublicKey(methodDetails.mint)
 
-      const amount = credential.challenge.request.amount
-      const expectedAmount = parseAmount(amount, methodDetails.decimals)
+        const amount = credential.challenge.request.amount
+        const expectedAmount = parseAmount(amount, methodDetails.decimals)
 
-      await findAndVerifyTransfer(
-        connection,
-        {
-          reference,
-          expectedRecipient,
-          expectedMint,
-          expectedAmount,
-          clientSignature: signature,
-        },
-        verifyTimeout,
-      )
+        await findAndVerifyTransfer(
+          connection,
+          {
+            reference,
+            expectedRecipient,
+            expectedMint,
+            expectedAmount,
+            clientSignature: signature,
+          },
+          verifyTimeout,
+        )
 
-      pendingReferences.delete(referenceKey)
+        // Mark consumed only after successful on-chain verification
+        if (store) {
+          const consumedKey = `solana-charge:consumed:${signature}`
+          await store.put(consumedKey, true)
+        }
 
-      return Receipt.from({
-        method: 'solana',
-        reference: signature,
-        status: 'success',
-        timestamp: new Date().toISOString(),
+        return Receipt.from({
+          method: 'solana',
+          reference: signature,
+          status: 'success',
+          timestamp: new Date().toISOString(),
+        })
       })
     },
   })

--- a/src/server/Session.ts
+++ b/src/server/Session.ts
@@ -24,7 +24,7 @@ interface SessionState {
   refundAddress: string
   mint: string
   decimals: number
-  status: 'active' | 'closed'
+  status: 'active' | 'closing' | 'closed'
 }
 
 export namespace session {
@@ -229,6 +229,10 @@ export function session(parameters: session.Parameters) {
     const state = await loadSession(payload.sessionId)
     verifyBearer(state, payload.bearer)
 
+    // Mark as closing before sending refund to prevent double-refund on retry
+    state.status = 'closing'
+    await store.put(`solana-session:${state.sessionId}`, serializeState(state))
+
     const refundAmount = state.depositAmount - state.spent
     if (refundAmount > BigInt(0)) {
       await sendRefund(state, refundAmount)
@@ -251,8 +255,8 @@ export function session(parameters: session.Parameters) {
     return deserializeState(raw)
   }
 
-  function verifyBearer(state: SessionState, bearer: string): void {
-    if (state.status !== 'active') {
+  function verifyBearer(state: SessionState, bearer: string, allowClosing = false): void {
+    if (state.status === 'closed' || (!allowClosing && state.status === 'closing')) {
       throw new Error(`Session ${state.sessionId} is ${state.status}`)
     }
     const hash = bytesToHex(sha256(new TextEncoder().encode(bearer)))
@@ -282,7 +286,12 @@ export function session(parameters: session.Parameters) {
     tx.feePayer = serverKeypair.publicKey
     tx.sign(serverKeypair)
 
-    await connection.sendRawTransaction(tx.serialize(), { skipPreflight: false })
+    const signature = await connection.sendRawTransaction(tx.serialize(), { skipPreflight: false })
+
+    await connection.confirmTransaction(
+      { signature, ...latestBlockhash },
+      'confirmed',
+    )
   }
 
   async function deduct(sessionId: string, amount: bigint): Promise<void> {
@@ -364,7 +373,7 @@ interface SerializedSessionState {
   refundAddress: string
   mint: string
   decimals: number
-  status: 'active' | 'closed'
+  status: 'active' | 'closing' | 'closed'
 }
 
 function serializeState(state: SessionState): SerializedSessionState {


### PR DESCRIPTION
## Summary
- **Charge replay ordering** — consumed marker now written *after* successful on-chain verification (not before), so RPC timeouts don't permanently burn valid payment signatures. Per-signature mutex prevents concurrent duplicate verification.
- **Dead code removal** — removed unused `pendingReferences` Map that grew without bound
- **Refund confirmation** — `sendRefund()` now calls `confirmTransaction` to ensure refund lands on-chain before session state changes
- **Close idempotency** — new `closing` intermediate state prevents double-refund if close is retried after process crash

## Issues Fixed
| # | Severity | Issue |
|---|----------|-------|
| 4 | HIGH | Charge replay protection burned valid payments on RPC timeout |
| 6 | HIGH | Refund fire-and-forget — session closed without confirming refund tx |
| 11 | MEDIUM | pendingReferences memory leak (partial — removed dead Map) |

## Test plan
- [ ] Verify charge with same signature is rejected on second attempt
- [ ] Verify RPC timeout during charge verification allows retry
- [ ] Verify refund transaction is confirmed before session marked closed
- [ ] Verify concurrent close calls don't send multiple refunds
- [ ] Build passes: `npm run build`