### PR TITLE
fix: deduplicate parseAmount and reject excess precision

### DIFF
--- a/src/client/Charge.ts
+++ b/src/client/Charge.ts
@@ -10,6 +10,7 @@ import {
 } from '@solana/spl-token'
 import * as Methods from '../Methods.js'
 import { clusterUrls, type SolanaNetwork } from '../constants.js'
+import { parseAmount } from '../utils.js'
 import type { WalletLike } from '../types.js'
 
 export namespace charge {
@@ -88,10 +89,3 @@ export function charge(parameters: charge.Parameters) {
   })
 }
 
-function parseAmount(amount: string, decimals: number): bigint {
-  const parts = amount.split('.')
-  const whole = parts[0] ?? '0'
-  let frac = parts[1] ?? ''
-  frac = frac.padEnd(decimals, '0').slice(0, decimals)
-  return BigInt(whole + frac)
-}

--- a/src/client/Session.ts
+++ b/src/client/Session.ts
@@ -10,6 +10,7 @@ import {
 } from '@solana/spl-token'
 import * as Methods from '../Methods.js'
 import { clusterUrls, type SolanaNetwork } from '../constants.js'
+import { parseAmount } from '../utils.js'
 import type { WalletLike } from '../types.js'
 
 interface ActiveSession {
@@ -202,10 +203,3 @@ async function sendTransfer(
   return signature
 }
 
-function parseAmount(amount: string, decimals: number): bigint {
-  const parts = amount.split('.')
-  const whole = parts[0] ?? '0'
-  let frac = parts[1] ?? ''
-  frac = frac.padEnd(decimals, '0').slice(0, decimals)
-  return BigInt(whole + frac)
-}

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,3 +8,4 @@ export * as client from './client/index.js'
 // Types
 export type { WalletLike, SolanaNetwork } from './types.js'
 export { clusterUrls } from './constants.js'
+export { parseAmount } from './utils.js'

--- a/src/server/Charge.ts
+++ b/src/server/Charge.ts
@@ -3,6 +3,7 @@ import { Connection, Keypair, PublicKey } from '@solana/web3.js'
 import { getAssociatedTokenAddress } from '@solana/spl-token'
 import * as Methods from '../Methods.js'
 import { clusterUrls, type SolanaNetwork } from '../constants.js'
+import { parseAmount } from '../utils.js'
 import { findAndVerifyTransfer } from './verify.js'
 
 export namespace charge {
@@ -113,10 +114,3 @@ export function charge(parameters: charge.Parameters) {
   })
 }
 
-function parseAmount(amount: string, decimals: number): bigint {
-  const parts = amount.split('.')
-  const whole = parts[0] ?? '0'
-  let frac = parts[1] ?? ''
-  frac = frac.padEnd(decimals, '0').slice(0, decimals)
-  return BigInt(whole + frac)
-}

--- a/src/server/Session.ts
+++ b/src/server/Session.ts
@@ -14,6 +14,7 @@ import { sha256 } from '@noble/hashes/sha2.js'
 import { bytesToHex } from '@noble/hashes/utils.js'
 import * as Methods from '../Methods.js'
 import { clusterUrls, type SolanaNetwork } from '../constants.js'
+import { parseAmount } from '../utils.js'
 import { findAndVerifyTransfer } from './verify.js'
 
 interface SessionState {
@@ -346,14 +347,6 @@ function computeTransferDelta(
   }
 
   return delta
-}
-
-function parseAmount(amount: string, decimals: number): bigint {
-  const parts = amount.split('.')
-  const whole = parts[0] ?? '0'
-  let frac = parts[1] ?? ''
-  frac = frac.padEnd(decimals, '0').slice(0, decimals)
-  return BigInt(whole + frac)
 }
 
 interface SerializedSessionState {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,22 @@
+/**
+ * Parse a human-readable decimal amount string into raw token units (bigint).
+ * Throws if the amount has more fractional digits than the token's decimals,
+ * preventing silent truncation that could misprice payments.
+ */
+export function parseAmount(amount: string, decimals: number): bigint {
+  const parts = amount.split('.')
+  if (parts.length > 2) {
+    throw new Error(`Invalid amount format: "${amount}"`)
+  }
+  const whole = parts[0] ?? '0'
+  const frac = parts[1] ?? ''
+
+  if (frac.length > decimals) {
+    throw new Error(
+      `Amount "${amount}" has ${frac.length} fractional digits, but token only supports ${decimals} decimals`,
+    )
+  }
+
+  const paddedFrac = frac.padEnd(decimals, '0')
+  return BigInt(whole + paddedFrac)
+}


### PR DESCRIPTION
## Summary
- Extract `parseAmount` into shared `src/utils.ts`, removing 4 identical copies
- **Fix silent truncation bug**: amounts with more fractional digits than the token supports now throw instead of silently rounding to zero (e.g. `"0.0000009"` with 6 decimals was becoming `0`)
- Export `parseAmount` from package root for consumer use

## Issues Fixed
| # | Severity | Issue |
|---|----------|-------|
| 7 | MEDIUM | parseAmount silently truncated excess precision, mispricing payments |
| 13 | LOW | parseAmount duplicated in 4 files |

## Test plan
- [ ] Verify `parseAmount("1.5", 6)` returns `1500000n`
- [ ] Verify `parseAmount("0.0000009", 6)` throws
- [ ] Verify `parseAmount("0.001", 6)` returns `1000n`
- [ ] Build passes: `npm run build`